### PR TITLE
feat: handle parametrized generics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           PLATFORM: ${{ matrix.platform }}
 
       - name: Coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
 
   deploy:
     name: Deploy

--- a/src/pydantic_generics/fields.py
+++ b/src/pydantic_generics/fields.py
@@ -1,11 +1,11 @@
 from contextlib import contextmanager
-from typing import Generic, Iterator, Type
+from typing import Generic, Iterator, get_origin, get_args, Iterable, Mapping
 
 import pydantic.config
 import pydantic.fields
 import pydantic.validators
 
-from .validators import simple_casting_validator
+from .validators import simple_casting_validator, element_casting_validator, mapping_casting_validator
 
 __all__ = ["ModelField"]
 
@@ -26,13 +26,17 @@ def generic_types_allowed(field: pydantic.fields.ModelField) -> Iterator[None]:
 
 
 @contextmanager
-def generic_validator_inserted(type_: Type) -> Iterator[None]:
-    v = (Generic, [simple_casting_validator(type_)])
-    pydantic.validators._VALIDATORS.insert(0, v)
+def generic_validator_inserted(field: pydantic.fields.ModelField) -> Iterator[None]:
+    v = [
+        (Mapping, [mapping_casting_validator(field), simple_casting_validator(field.type_)]),
+        (Iterable, [element_casting_validator(field), simple_casting_validator(field.type_)]),
+        (Generic, [simple_casting_validator(field.type_)]),
+    ]
+    before, pydantic.validators._VALIDATORS = pydantic.validators._VALIDATORS, v + pydantic.validators._VALIDATORS
     try:
         yield
     finally:
-        pydantic.validators._VALIDATORS.pop(0)
+        pydantic.validators._VALIDATORS = before
 
 
 class ModelField(pydantic.fields.ModelField):
@@ -40,5 +44,29 @@ class ModelField(pydantic.fields.ModelField):
         # XXX: not sure I like this, "generic_types_allowed"
         # the alternative would be to just say
         # "you have to use arbitrary_types_allowed if you want to use this"
-        with generic_types_allowed(self), generic_validator_inserted(self.type_):
+        with generic_types_allowed(self), generic_validator_inserted(self):
             super().populate_validators()
+            # override self.validators generation, cause we need *both* class validators
+            # and generic validators
+            # TODO: not sure about this. Without this change, if we create validators, no "smart"
+            # validation happens (so we have to manually validate fields for lists, for example).
+            # However, with it we force type coercion no matter what, even in cases where maybe we don't want it
+            class_validators_ = self.class_validators.values()
+            if not self.sub_fields or self.shape == pydantic.fields.SHAPE_GENERIC:
+                get_validators = getattr(self.type_, '__get_validators__', list)
+                v_funcs = (
+                    *[v.func for v in class_validators_ if v.each_item and v.pre],
+                    *get_validators(),
+                    *list(pydantic.fields.find_validators(self.type_, self.model_config)),
+                    *[v.func for v in class_validators_ if v.each_item and not v.pre],
+                )
+                self.validators = pydantic.class_validators.prep_validators(v_funcs)
+
+    def _type_analysis(self):
+        origin = get_origin(self.outer_type_)
+        if origin is None or not isinstance(origin, type) or not issubclass(origin, Generic):
+            super()._type_analysis()
+        else:
+            self.shape = pydantic.fields.SHAPE_GENERIC
+            self.sub_fields = [self._create_sub_type(t, f'{self.name}_{i}') for i, t in enumerate(get_args(self.type_))]
+            self.type_ = origin

--- a/src/pydantic_generics/validators.py
+++ b/src/pydantic_generics/validators.py
@@ -1,3 +1,4 @@
+from itertools import zip_longest
 from typing import Any, Callable, Type, TypeVar
 
 import pydantic.errors
@@ -24,3 +25,58 @@ def simple_casting_validator(type_: Type[T]) -> Callable[[T], T]:
             ) from e
 
     return arbitrary_type_validator
+
+
+class Missing:
+    pass
+
+
+def element_casting_validator(field) -> Callable[[T], T]:
+    def cast_elements(v: Any) -> T:
+        if not field.sub_fields:
+            return v
+
+        result = []
+        if len(field.sub_fields) == 1:
+            f = field.sub_fields[0]
+            for i, v_ in enumerate(v):
+                r, e = f.validate(v_, {}, loc=i)
+                if e:
+                    raise CannotCastError(type=f.type_, error='')
+                result.append(r)
+            return result
+        else:
+            for i, (v_, f) in enumerate(zip_longest(v, field.sub_fields, fillvalue=Missing)):
+                if v_ is Missing or f is Missing:
+                    raise ValueError('args must be either a single one, or as many as there are elements')
+                r, e = f.validate(v_, {}, loc=i)
+                if e:
+                    raise CannotCastError(type=f.type_, error='')
+                result.append(r)
+            return result
+
+    return cast_elements
+
+
+def mapping_casting_validator(field) -> Callable[[T], T]:
+    def cast_elements(v: Any) -> T:
+        if not field.sub_fields:
+            return v
+
+        if len(field.sub_fields) != 2:
+            raise ValueError('must pass 2 fields to mapping')
+
+        result = {}
+        for i, (k_, v_) in enumerate(v.items()):
+            f_key = field.sub_fields[0]
+            k, e = f_key.validate(k_, {}, loc=i)
+            if e:
+                raise CannotCastError(type=f_key.type_, error='')
+            f_val = field.sub_fields[1]
+            v, e = f_val.validate(v_, {}, loc=i)
+            if e:
+                raise CannotCastError(type=f_val.type_, error='')
+            result[k] = v
+        return result
+
+    return cast_elements

--- a/tests/test_pydantic_generics.py
+++ b/tests/test_pydantic_generics.py
@@ -204,7 +204,7 @@ def test_parametrized_generics(field: type, value: Any, expected: Any) -> None:
 
 OTHER_CASES = [
     # union tries to coerce in order and stops as soon as it succeeds
-    (Union[str, float], 1.0, '1', str),
+    (Union[str, float], 1.0, '1.0', str),
     (Union[float, str], '1', 1.0, float),
     # optional should not fail with None
     (Optional[int], None, None, type(None)),

--- a/tests/test_pydantic_generics.py
+++ b/tests/test_pydantic_generics.py
@@ -108,7 +108,7 @@ class MyMutableMapping(_ReprMixin, MutableMapping[T, U]):
         self.v = dict(v)
 
 
-class MyValidatingMutableMapping(_ClassValidatorMixin, MyMutableMapping[T]):
+class MyValidatingMutableMapping(_ClassValidatorMixin, MyMutableMapping[T, U]):
     pass
 
 

--- a/tests/test_pydantic_generics.py
+++ b/tests/test_pydantic_generics.py
@@ -122,6 +122,14 @@ class MyValidatingMutableMapping(_ClassValidatorMixin, MyMutableMapping[T]):
     pass
 
 
+class MyString(str):
+    pass
+
+
+class MyValidatingString(_ClassValidatorMixin, MyString):
+    pass
+
+
 CASES = [
     (MyGeneric, 1),
     (MyGenericSequence, [1]),
@@ -209,7 +217,9 @@ OTHER_CASES = [
     (Union[float, str], '1', '1', str),
     (Optional[int], None, None, type(None)),
     (Optional[int], 1, 1, int),
-    (Literal[1], 1, 1, int)
+    (Literal[1], 1, 1, int),
+    (MyString, '1', '1', MyString),
+    (MyValidatingString, '1', '1', MyValidatingString),
 ]
 
 

--- a/tests/test_pydantic_generics.py
+++ b/tests/test_pydantic_generics.py
@@ -213,11 +213,15 @@ def test_parametrized_generics(field: type, value: Any, expected: Any) -> None:
 
 
 OTHER_CASES = [
-    (Union[str, float], 1.0, 1.0, float),
-    (Union[float, str], '1', '1', str),
+    # union tries to coerce in order and stops as soon as it succeeds
+    (Union[str, float], 1.0, '1', str),
+    (Union[float, str], '1', 1.0, float),
+    # optional should not fail with None
     (Optional[int], None, None, type(None)),
     (Optional[int], 1, 1, int),
+    # Literal is not a subclass of type, so it can cause issues when using `issubclass`
     (Literal[1], 1, 1, int),
+    # subclass of builtin
     (MyString, '1', '1', MyString),
     (MyValidatingString, '1', '1', MyValidatingString),
 ]

--- a/tests/test_pydantic_generics.py
+++ b/tests/test_pydantic_generics.py
@@ -47,14 +47,11 @@ class MyValidatingGeneric(_ClassValidatorMixin, MyGeneric[T]):
 
 
 class MyGenericSequence(_ReprMixin, Sequence[T]):
+    __len__ = None
+    __getitem__ = None
+
     def __init__(self, data: Sequence[T]):
         self.v = list(data)
-
-    def __getitem__(self, index: int) -> T:  # type: ignore
-        return self.v[index]
-
-    def __len__(self) -> int:
-        return len(self.v)
 
 
 class MyValidatingGenericSequence(_ClassValidatorMixin, MyGenericSequence[T]):
@@ -64,9 +61,6 @@ class MyValidatingGenericSequence(_ClassValidatorMixin, MyGenericSequence[T]):
 class MyList(_ReprMixin, List[T]):
     def __init__(self, v):
         self.v = list(v)
-
-    def __iter__(self):
-        yield from self.v
 
 
 class MyValidatingList(_ClassValidatorMixin, MyList[T]):
@@ -91,14 +85,12 @@ class MyValidatingMutableSequence(_ClassValidatorMixin, MyMutableSequence[T]):
 class MyMutableSet(_ReprMixin, MutableSet[T]):
     __contains__ = None
     __len__ = None
+    __iter__ = None
     add = None
     discard = None
 
     def __init__(self, v):
         self.v = set(v)
-
-    def __iter__(self):
-        yield from self.v
 
 
 class MyValidatingMutableSet(_ClassValidatorMixin, MyMutableSet[T]):
@@ -110,12 +102,10 @@ class MyMutableMapping(_ReprMixin, MutableMapping[T, U]):
     __getitem__ = None
     __len__ = None
     __setitem__ = None
+    __iter__ = None
 
     def __init__(self, v):
         self.v = dict(v)
-
-    def __iter__(self):
-        yield from self.v
 
 
 class MyValidatingMutableMapping(_ClassValidatorMixin, MyMutableMapping[T]):

--- a/tests/test_pydantic_generics.py
+++ b/tests/test_pydantic_generics.py
@@ -8,6 +8,9 @@ from typing import (
     Sequence,
     TypeVar,
     get_origin,
+    Union,
+    Literal,
+    Optional,
 )
 
 import pytest
@@ -18,38 +21,59 @@ T = TypeVar("T")
 U = TypeVar("U")
 
 
-class MyGeneric(Generic[T]):
-    def __init__(self, value: T):
-        self.value = value
-
-
-class MyGenericSequence(Sequence[T]):
-    def __init__(self, data: Sequence[T]):
-        self._data = list(data)
-
-    def __getitem__(self, index: int) -> T:  # type: ignore
-        return self._data[index]
-
-    def __len__(self) -> int:
-        return len(self._data)
-
-
-class _CastMixin:
+class _ClassValidatorMixin:
     @classmethod
     def __get_validators__(cls):
         yield cls.v
 
     @classmethod
     def v(cls, v):
-        return cls(v)
+        # not a coercing validator!
+        return v
 
 
-class MyList(List[T]):
+class _ReprMixin:
+    def __repr__(self):
+        return f'{self.__class__.__name__}({repr(self.v)})'
+
+
+class MyGeneric(_ReprMixin, Generic[T]):
+    def __init__(self, value: T):
+        self.v = value
+
+
+class MyValidatingGeneric(_ClassValidatorMixin, MyGeneric[T]):
+    pass
+
+
+class MyGenericSequence(_ReprMixin, Sequence[T]):
+    def __init__(self, data: Sequence[T]):
+        self.v = list(data)
+
+    def __getitem__(self, index: int) -> T:  # type: ignore
+        return self.v[index]
+
+    def __len__(self) -> int:
+        return len(self.v)
+
+
+class MyValidatingGenericSequence(_ClassValidatorMixin, MyGenericSequence[T]):
+    pass
+
+
+class MyList(_ReprMixin, List[T]):
     def __init__(self, v):
-        self.v = v
+        self.v = list(v)
+
+    def __iter__(self):
+        yield from self.v
 
 
-class MyMutableSequence(MutableSequence[T]):
+class MyValidatingList(_ClassValidatorMixin, MyList[T]):
+    pass
+
+
+class MyMutableSequence(_ReprMixin, MutableSequence[T]):
     __delitem__ = None
     __getitem__ = None
     __len__ = None
@@ -57,29 +81,45 @@ class MyMutableSequence(MutableSequence[T]):
     insert = None
 
     def __init__(self, v):
-        self.v = v
+        self.v = list(v)
 
 
-class MyMutableSet(MutableSet[T]):
+class MyValidatingMutableSequence(_ClassValidatorMixin, MyMutableSequence[T]):
+    pass
+
+
+class MyMutableSet(_ReprMixin, MutableSet[T]):
     __contains__ = None
-    __iter__ = None
     __len__ = None
     add = None
     discard = None
 
     def __init__(self, v):
-        self.v = v
+        self.v = set(v)
+
+    def __iter__(self):
+        yield from self.v
 
 
-class MyMutableMapping(MutableMapping[T, U]):
+class MyValidatingMutableSet(_ClassValidatorMixin, MyMutableSet[T]):
+    pass
+
+
+class MyMutableMapping(_ReprMixin, MutableMapping[T, U]):
     __delitem__ = None
     __getitem__ = None
     __len__ = None
-    __iter__ = None
     __setitem__ = None
 
     def __init__(self, v):
-        self.v = v
+        self.v = dict(v)
+
+    def __iter__(self):
+        yield from self.v
+
+
+class MyValidatingMutableMapping(_ClassValidatorMixin, MyMutableMapping[T]):
+    pass
 
 
 CASES = [
@@ -91,26 +131,93 @@ CASES = [
     (MyMutableSequence, [1]),
     (MyMutableSet, {1}),
     (MyMutableMapping, {1: 2}),
-]
-
-
-PARAMETRIZED_CASES = [
-    (MyGeneric[int], 1),
-    (MyGenericSequence[int], [1]),
-    (MyGeneric[int], 1),
-    (MyGenericSequence[int], [1]),
-    (MyMutableSequence[str], [1]),
-    (MyList[str], [1]),
-    (MyMutableMapping[str, str], {1: 2}),
-    (MyMutableSequence[str], {1}),
+    (MyValidatingGeneric, 1),
+    (MyValidatingGenericSequence, [1]),
+    (MyValidatingGeneric, 1),
+    (MyValidatingGenericSequence, [1]),
+    (MyValidatingList, [1]),
+    (MyValidatingMutableSequence, [1]),
+    (MyValidatingMutableSet, {1}),
+    (MyValidatingMutableMapping, {1: 2}),
+    # input of different type that can be coerced
+    (MyGenericSequence, {1}),
+    (MyList, {1}),
+    (MyMutableSequence, {1}),
+    (MyMutableSet, [1]),
+    (MyValidatingGenericSequence, {1}),
+    (MyValidatingList, {1}),
+    (MyValidatingMutableSequence, {1}),
+    (MyValidatingMutableSet, [1]),
 ]
 
 
 @pytest.mark.parametrize("field, value", CASES)
-def test_something(field: type, value: Any) -> None:
+def test_simple_generics(field: type, value: Any) -> None:
     Model = create_model("Model", x=(field, ...))
     assert issubclass(Model, BaseModel)
     instance = Model(x=value)
     attr = getattr(instance, "x")
     custom_type = get_origin(field) or field
     assert isinstance(attr, custom_type)
+
+
+PARAMETRIZED_CASES = [
+    (MyGeneric[int], 1, 1),
+    (MyGenericSequence[int], [1], [1]),
+    (MyGeneric[int], 1, 1),
+    (MyGenericSequence[int], [1], [1]),
+    (MyMutableSet[int], {1}, {1}),
+    (MyValidatingGeneric[int], 1, 1),
+    (MyValidatingGenericSequence[int], [1], [1]),
+    (MyValidatingGeneric[int], 1, 1),
+    (MyValidatingGenericSequence[int], [1], [1]),
+    (MyValidatingMutableSet[int], {1}, {1}),
+    # coerce element type
+    (MyMutableSequence[str], [1], ['1']),
+    (MyList[str], [1], ['1']),
+    (MyMutableMapping[str, str], {1: 2}, {'1': '2'}),
+    (MyMutableSet[str], {1}, {'1'}),
+    (MyMutableSequence[str], {1}, ['1']),
+    (MyValidatingMutableSequence[str], [1], ['1']),
+    (MyValidatingList[str], [1], ['1']),
+    (MyValidatingMutableMapping[str, str], {1: 2}, {'1': '2'}),
+    (MyValidatingMutableSet[str], {1}, {'1'}),
+    (MyValidatingMutableSequence[str], {1}, ['1']),
+    # coerce container type as well
+    (MyMutableSequence[str], {1}, ['1']),
+    (MyList[str], {1}, ['1']),
+    (MyMutableSet[str], [1], {'1'}),
+    (MyValidatingMutableSequence[str], {1}, ['1']),
+    (MyValidatingList[str], {1}, ['1']),
+    (MyValidatingMutableSet[str], [1], {'1'}),
+]
+
+
+@pytest.mark.parametrize("field, value, expected", PARAMETRIZED_CASES)
+def test_parametrized_generics(field: type, value: Any, expected: Any) -> None:
+    Model = create_model("Model", x=(field, ...))
+    assert issubclass(Model, BaseModel)
+    instance = Model(x=value)
+    attr = getattr(instance, "x")
+    custom_type = get_origin(field) or field
+    assert isinstance(attr, custom_type)
+    assert attr.v == expected
+
+
+OTHER_CASES = [
+    (Union[str, float], 1.0, 1.0, float),
+    (Union[float, str], '1', '1', str),
+    (Optional[int], None, None, type(None)),
+    (Optional[int], 1, 1, int),
+    (Literal[1], 1, 1, int)
+]
+
+
+@pytest.mark.parametrize("field, value, expected, expected_type", OTHER_CASES)
+def test_other_types(field: type, value: Any, expected: Any, expected_type: type) -> None:
+    Model = create_model("Model", x=(field, ...))
+    assert issubclass(Model, BaseModel)
+    instance = Model(x=value)
+    attr = getattr(instance, "x")
+    assert attr == expected
+    assert type(attr) is expected_type


### PR DESCRIPTION
I added a lot of tests and slowly made my way trhough them; now almost everything works.

Main changes:
1. added two more validators that do the same as `validat_sequence_like`, but preserving type because they're followed up by the type coercing validator
2. forced into the `SHAPE_GENERIC` branch anything that should end up there and wasn't (all the parametrized sequence-like, mapping-like and so on), so we can use our own validators from point 1.