### PR TITLE
test: more tests and fix tuple

### DIFF
--- a/src/pydantic_generics/fields.py
+++ b/src/pydantic_generics/fields.py
@@ -68,5 +68,10 @@ class ModelField(pydantic.fields.ModelField):
             super()._type_analysis()
         else:
             self.shape = pydantic.fields.SHAPE_GENERIC
-            self.sub_fields = [self._create_sub_type(t, f'{self.name}_{i}') for i, t in enumerate(get_args(self.type_))]
+            # ellipsis breaks everything down the line, and is otherwise useless other than for static typing
+            self.sub_fields = [
+                self._create_sub_type(t, f'{self.name}_{i}')
+                for i, t in enumerate(get_args(self.type_))
+                if t is not Ellipsis
+            ]
             self.type_ = origin

--- a/tests/test_pydantic_generics.py
+++ b/tests/test_pydantic_generics.py
@@ -11,14 +11,19 @@ from typing import (
     Union,
     Literal,
     Optional,
+    Iterable,
+    Mapping,
+    Tuple,
 )
 
 import pytest
+from pydantic.error_wrappers import ValidationError
 
 from pydantic_generics import BaseModel, create_model
 
 T = TypeVar("T")
 U = TypeVar("U")
+V = TypeVar("V")
 
 
 class _ClassValidatorMixin:
@@ -64,6 +69,15 @@ class MyList(_ReprMixin, List[T]):
 
 
 class MyValidatingList(_ClassValidatorMixin, MyList[T]):
+    pass
+
+
+class MyTuple(_ReprMixin, Tuple[T]):
+    def __init__(self, v):
+        self.v = tuple(v)
+
+
+class MyValidatingTuple(_ClassValidatorMixin, MyTuple[T]):
     pass
 
 
@@ -120,6 +134,16 @@ class MyValidatingString(_ClassValidatorMixin, MyString):
     pass
 
 
+class MyTripleParameterIterable(Generic[T, U, V]):
+    """Not a subclass of iterable, but technically iterable"""
+
+    def __init__(self, v):
+        self.v = list(v)
+
+    def __iter__(self):
+        yield from self.v
+
+
 CASES = [
     (MyGeneric, 1),
     (MyGenericSequence, [1]),
@@ -134,16 +158,19 @@ CASES = [
     (MyValidatingGeneric, 1),
     (MyValidatingGenericSequence, [1]),
     (MyValidatingList, [1]),
+    (MyValidatingTuple, (1,)),
     (MyValidatingMutableSequence, [1]),
     (MyValidatingMutableSet, {1}),
     (MyValidatingMutableMapping, {1: 2}),
     # input of different type that can be coerced
     (MyGenericSequence, {1}),
     (MyList, {1}),
+    (MyTuple, [1]),
     (MyMutableSequence, {1}),
     (MyMutableSet, [1]),
     (MyValidatingGenericSequence, {1}),
     (MyValidatingList, {1}),
+    (MyValidatingTuple, {1}),
     (MyValidatingMutableSequence, {1}),
     (MyValidatingMutableSet, [1]),
 ]
@@ -173,21 +200,30 @@ PARAMETRIZED_CASES = [
     # coerce element type
     (MyMutableSequence[str], [1], ['1']),
     (MyList[str], [1], ['1']),
+    (MyTuple[str], (1,), ('1',)),
     (MyMutableMapping[str, str], {1: 2}, {'1': '2'}),
     (MyMutableSet[str], {1}, {'1'}),
     (MyMutableSequence[str], {1}, ['1']),
     (MyValidatingMutableSequence[str], [1], ['1']),
     (MyValidatingList[str], [1], ['1']),
+    (MyValidatingTuple[str], (1,), ('1',)),
     (MyValidatingMutableMapping[str, str], {1: 2}, {'1': '2'}),
     (MyValidatingMutableSet[str], {1}, {'1'}),
     (MyValidatingMutableSequence[str], {1}, ['1']),
     # coerce container type as well
     (MyMutableSequence[str], {1}, ['1']),
     (MyList[str], {1}, ['1']),
+    (MyTuple[str], {1}, ('1',)),
     (MyMutableSet[str], [1], {'1'}),
     (MyValidatingMutableSequence[str], {1}, ['1']),
     (MyValidatingList[str], {1}, ['1']),
+    (MyValidatingTuple[str], {1}, ('1',)),
     (MyValidatingMutableSet[str], [1], {'1'}),
+    (MyList[int], '123', [1, 2, 3]),
+    # multiple parameters for iterable will validate one by one
+    (MyList[int, float, str], [1, 2, 3], [1, 2.0, '3']),
+    # tuple accepts ellipsis
+    (MyTuple[str, ...], (1, 2), ('1', '2')),
 ]
 
 
@@ -199,6 +235,12 @@ def test_parametrized_generics(field: type, value: Any, expected: Any) -> None:
     attr = getattr(instance, "x")
     custom_type = get_origin(field) or field
     assert isinstance(attr, custom_type)
+    if issubclass(custom_type, Iterable):
+        assert all(v == e for v, e in zip(attr.v, expected))
+        assert all(type(v) == type(e) for v, e in zip(attr.v, expected))
+    if issubclass(custom_type, Mapping):
+        assert all(v == e for v, e in zip(attr.v.values(), expected.values()))
+        assert all(type(v) == type(e) for v, e in zip(attr.v.values(), expected.values()))
     assert attr.v == expected
 
 
@@ -225,3 +267,26 @@ def test_other_types(field: type, value: Any, expected: Any, expected_type: type
     attr = getattr(instance, "x")
     assert attr == expected
     assert type(attr) is expected_type
+
+
+FAILING_CASES = [
+    (MyGenericSequence, 1),
+    (MyMutableSequence, None),
+    (MyMutableSet, {1: 2}),
+    (MyMutableMapping, [1]),
+    (MyGeneric[int], 'a'),
+    (MyGenericSequence[int], 'asd'),
+    (MyMutableMapping[int, int], {'a': 'b'}),
+    # different length of parameters and value
+    (MyList[int, float, str], [1, 2]),
+    # TODO: this should not fail like this
+    (MyTripleParameterIterable[int, float, str], [1]),
+]
+
+
+@pytest.mark.parametrize("field, value", FAILING_CASES)
+def test_incompatible_types(field: type, value: Any) -> None:
+    Model = create_model("Model", x=(field, ...))
+    assert issubclass(Model, BaseModel)
+    # with pytest.raises(ValidationError):
+    Model(x=value)

--- a/tests/test_pydantic_generics.py
+++ b/tests/test_pydantic_generics.py
@@ -237,7 +237,7 @@ PARAMETRIZED_CASES = [
     (MyValidatingMutableSet[str], [1], {'1'}),
     (MyList[int], '123', [1, 2, 3]),
     # multiple parameters for iterable will validate one by one
-    (MyList[int, float, str], [1, 2, 3], [1, 2.0, '3']),
+    (MyTuple[int, float, str], [1, 2, 3], (1, 2.0, '3')),
     # tuple accepts ellipsis
     (MyTuple[str, ...], (1, 2), ('1', '2')),
     (MyGenericWithCustomValidator[str, int], 'a', 'first'),
@@ -294,7 +294,7 @@ FAILING_CASES = [
     (MyGenericSequence[int], 'asd'),
     (MyMutableMapping[int, int], {'a': 'b'}),
     # different length of parameters and value
-    (MyList[int, float, str], [1, 2]),
+    (MyTuple[int, float, str], [1, 2]),
     # TODO: this should not fail like this
     (MyTripleParameterIterable[int, float, str], [1]),
 ]

--- a/tests/test_pydantic_generics.py
+++ b/tests/test_pydantic_generics.py
@@ -14,6 +14,7 @@ from typing import (
     Iterable,
     Mapping,
     Tuple,
+    Callable,
 )
 
 import pytest
@@ -262,6 +263,10 @@ def test_parametrized_generics(field: type, value: Any, expected: Any) -> None:
     assert attr.v == expected
 
 
+def noop():
+    pass
+
+
 OTHER_CASES = [
     # union tries to coerce in order and stops as soon as it succeeds
     (Union[str, float], 1.0, '1.0', str),
@@ -274,6 +279,7 @@ OTHER_CASES = [
     # subclass of builtin
     (MyString, '1', '1', MyString),
     (MyValidatingString, '1', '1', MyValidatingString),
+    (Callable, noop, noop, type(noop)),
 ]
 
 

--- a/tests/test_pydantic_generics.py
+++ b/tests/test_pydantic_generics.py
@@ -297,6 +297,7 @@ FAILING_CASES = [
     (MyTuple[int, float, str], [1, 2]),
     # TODO: this should not fail like this
     (MyTripleParameterIterable[int, float, str], [1]),
+    (MyTuple[int], (1, 1)),
 ]
 
 


### PR DESCRIPTION
Added a bunch of tests and improved the ones we have to check more thoroughly for element types. Some of the new tests are supposed to fail, but one of the failing ones is not ideal (the iterable one), though it's an edge case that shouldn't be a big deal.

I also fixed the `Tuple[int, ...]` case, by simply ignoring the ellipsis and falling back to the 1 by 1 case. One downside is that `Tuple[int]` now will accept `(1, 1)`. Need to change that.