### PR TITLE
fix: a bunch of things

### DIFF
--- a/src/pydantic_generics/__init__.py
+++ b/src/pydantic_generics/__init__.py
@@ -9,7 +9,7 @@ except PackageNotFoundError:
 __author__ = "Talley Lambert"
 __email__ = "talley.lambert@gmail.com"
 
-from .main import BaseModel, create_model
+from .main import BaseModel, ModelMetaclass, create_model
 from .monkeypatch import patched_pydantic_base_model
 
-__all__ = ["BaseModel", "create_model", "patched_pydantic_base_model"]
+__all__ = ["BaseModel", "ModelMetaclass", "create_model", "patched_pydantic_base_model"]

--- a/src/pydantic_generics/fields.py
+++ b/src/pydantic_generics/fields.py
@@ -1,11 +1,12 @@
 from contextlib import contextmanager
 from typing import Generic, Iterator, get_origin, get_args, Iterable, Mapping, Tuple
+from dataclasses import is_dataclass
 
 import pydantic.config
 import pydantic.fields
 import pydantic.validators
 
-from .validators import simple_casting_validator, element_casting_validator, mapping_casting_validator, tuple_element_casting_validator
+from .validators import simple_casting_validator, element_casting_validator, mapping_casting_validator, tuple_element_casting_validator, coerce_dataclass_validator
 
 __all__ = ["ModelField"]
 
@@ -45,6 +46,9 @@ class ModelField(pydantic.fields.ModelField):
                     *[v.func for v in class_validators_ if v.each_item and not v.pre],
                 )
                 self.validators = pydantic.class_validators.prep_validators(v_funcs)
+
+            if is_dataclass(self.type_):
+                self.validators.extend(pydantic.class_validators.prep_validators([coerce_dataclass_validator(self.type_)]))
 
     def _type_analysis(self):
         origin = get_origin(self.outer_type_)

--- a/src/pydantic_generics/main.py
+++ b/src/pydantic_generics/main.py
@@ -2,13 +2,13 @@ from typing import Any, Type, no_type_check
 
 import pydantic.main
 
-from .monkeypatch import patched_pydantic_base_model, patched_pydantic_model_field, force_arbitrary_types_allowed
+from .monkeypatch import patched_pydantic_base_model, patched_pydantic_model_field, force_arbitrary_types_allowed, patched_dataclass_validator
 
 
 class ModelMetaclass(pydantic.main.ModelMetaclass):
     @no_type_check
     def __new__(cls, name, bases, namespace, **kwargs):
-        with patched_pydantic_model_field(), force_arbitrary_types_allowed(namespace):
+        with patched_pydantic_model_field(), patched_dataclass_validator(), force_arbitrary_types_allowed(namespace):
             return super().__new__(cls, name, bases, namespace, **kwargs)
 
 

--- a/src/pydantic_generics/main.py
+++ b/src/pydantic_generics/main.py
@@ -1,19 +1,36 @@
+from contextlib import contextmanager
 from typing import Any, Type, no_type_check
 
 import pydantic.main
 
-from .monkeypatch import patched_pydantic_base_model, patched_pydantic_model_field, force_arbitrary_types_allowed, patched_dataclass_validator
+from .monkeypatch import patched_pydantic_base_model, patched_pydantic_model_field, patched_dataclass_validator
+
+
+is_basemodel = False
+
+
+@contextmanager
+def is_basemodel():
+    # allows us to declare BaseModel without triggering the arbitrary_types_allowed error
+    global is_basemodel
+    is_basemodel = True
+    yield
+    is_basemodel = False
 
 
 class ModelMetaclass(pydantic.main.ModelMetaclass):
     @no_type_check
     def __new__(cls, name, bases, namespace, **kwargs):
-        with patched_pydantic_model_field(), patched_dataclass_validator(), force_arbitrary_types_allowed(namespace):
-            return super().__new__(cls, name, bases, namespace, **kwargs)
+        with patched_pydantic_model_field(), patched_dataclass_validator():
+            new_cls = super().__new__(cls, name, bases, namespace, **kwargs)
+            if not is_basemodel and not new_cls.__config__.arbitrary_types_allowed:
+                raise ValueError('arbitrary_types_allowed must be True for pydantic_generics to work')
+            return new_cls
 
 
-class BaseModel(pydantic.main.BaseModel, metaclass=ModelMetaclass):
-    pass
+with is_basemodel():
+    class BaseModel(pydantic.main.BaseModel, metaclass=ModelMetaclass):
+        pass
 
 
 def create_model(__model_name: str, **kwargs: Any) -> Type["BaseModel"]:

--- a/src/pydantic_generics/main.py
+++ b/src/pydantic_generics/main.py
@@ -1,4 +1,3 @@
-from contextlib import contextmanager
 from typing import Any, Type, no_type_check
 
 import pydantic.main
@@ -6,16 +5,7 @@ import pydantic.main
 from .monkeypatch import patched_pydantic_base_model, patched_pydantic_model_field, patched_dataclass_validator
 
 
-is_basemodel = False
-
-
-@contextmanager
-def is_basemodel():
-    # allows us to declare BaseModel without triggering the arbitrary_types_allowed error
-    global is_basemodel
-    is_basemodel = True
-    yield
-    is_basemodel = False
+_is_base_model_class_defined = False
 
 
 class ModelMetaclass(pydantic.main.ModelMetaclass):
@@ -23,14 +13,16 @@ class ModelMetaclass(pydantic.main.ModelMetaclass):
     def __new__(cls, name, bases, namespace, **kwargs):
         with patched_pydantic_model_field(), patched_dataclass_validator():
             new_cls = super().__new__(cls, name, bases, namespace, **kwargs)
-            if not is_basemodel and not new_cls.__config__.arbitrary_types_allowed:
+            if _is_base_model_class_defined and not new_cls.__config__.arbitrary_types_allowed:
                 raise ValueError('arbitrary_types_allowed must be True for pydantic_generics to work')
             return new_cls
 
 
-with is_basemodel():
-    class BaseModel(pydantic.main.BaseModel, metaclass=ModelMetaclass):
-        pass
+class BaseModel(pydantic.main.BaseModel, metaclass=ModelMetaclass):
+    pass
+
+
+_is_base_model_class_defined = True
 
 
 def create_model(__model_name: str, **kwargs: Any) -> Type["BaseModel"]:

--- a/src/pydantic_generics/main.py
+++ b/src/pydantic_generics/main.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any, Type, no_type_check
 
 import pydantic.main
@@ -9,7 +10,11 @@ class ModelMetaclass(pydantic.main.ModelMetaclass):
     @no_type_check
     def __new__(cls, name, bases, namespace, **kwargs):
         with patched_pydantic_model_field():
-            return super().__new__(cls, name, bases, namespace, **kwargs)
+            cls = super().__new__(cls, name, bases, namespace, **kwargs)
+            if not cls.__config__.arbitrary_types_allowed:
+                warnings.warn('pydantic_generics.BaseModel requires `arbitrary_types_allowed`, so it was automatically enabled')
+                cls.__config__.arbitrary_types_allowed = True
+            return cls
 
 
 class BaseModel(pydantic.main.BaseModel, metaclass=ModelMetaclass):

--- a/src/pydantic_generics/main.py
+++ b/src/pydantic_generics/main.py
@@ -1,20 +1,15 @@
-import warnings
 from typing import Any, Type, no_type_check
 
 import pydantic.main
 
-from .monkeypatch import patched_pydantic_base_model, patched_pydantic_model_field
+from .monkeypatch import patched_pydantic_base_model, patched_pydantic_model_field, force_arbitrary_types_allowed
 
 
 class ModelMetaclass(pydantic.main.ModelMetaclass):
     @no_type_check
     def __new__(cls, name, bases, namespace, **kwargs):
-        with patched_pydantic_model_field():
-            cls = super().__new__(cls, name, bases, namespace, **kwargs)
-            if not cls.__config__.arbitrary_types_allowed:
-                warnings.warn('pydantic_generics.BaseModel requires `arbitrary_types_allowed`, so it was automatically enabled')
-                cls.__config__.arbitrary_types_allowed = True
-            return cls
+        with patched_pydantic_model_field(), force_arbitrary_types_allowed(namespace):
+            return super().__new__(cls, name, bases, namespace, **kwargs)
 
 
 class BaseModel(pydantic.main.BaseModel, metaclass=ModelMetaclass):

--- a/src/pydantic_generics/monkeypatch.py
+++ b/src/pydantic_generics/monkeypatch.py
@@ -43,3 +43,22 @@ def patched_make_arbitrary_type_validator() -> Iterator[None]:
         yield
     finally:
         pydantic.validators.make_arbitrary_type_validator = orig
+
+
+@contextmanager
+def force_arbitrary_types_allowed(namespace):
+    old_cfg = namespace.get('Config', None)
+    if old_cfg is None:
+        try:
+            cfg = type('Config', (), {'arbitrary_types_allowed': True})
+            namespace['Config'] = cfg
+            yield
+        finally:
+            del namespace['Config']
+
+    else:
+        try:
+            old_cfg.arbitrary_types_allowed = True
+            yield
+        finally:
+            old_cfg.arbitrary_types_allowed = False

--- a/src/pydantic_generics/monkeypatch.py
+++ b/src/pydantic_generics/monkeypatch.py
@@ -46,25 +46,6 @@ def patched_make_arbitrary_type_validator() -> Iterator[None]:
 
 
 @contextmanager
-def force_arbitrary_types_allowed(namespace):
-    old_cfg = namespace.get('Config', None)
-    if old_cfg is None:
-        try:
-            cfg = type('Config', (), {'arbitrary_types_allowed': True})
-            namespace['Config'] = cfg
-            yield
-        finally:
-            del namespace['Config']
-
-    else:
-        try:
-            old_cfg.arbitrary_types_allowed = True
-            yield
-        finally:
-            old_cfg.arbitrary_types_allowed = False
-
-
-@contextmanager
 def patched_dataclass_validator():
     from .validators import _validate_dataclass
 

--- a/src/pydantic_generics/monkeypatch.py
+++ b/src/pydantic_generics/monkeypatch.py
@@ -62,3 +62,14 @@ def force_arbitrary_types_allowed(namespace):
             yield
         finally:
             old_cfg.arbitrary_types_allowed = False
+
+
+@contextmanager
+def patched_dataclass_validator():
+    from .validators import _validate_dataclass
+
+    orig, pydantic.dataclasses._validate_dataclass = pydantic.dataclasses._validate_dataclass, _validate_dataclass
+    try:
+        yield
+    finally:
+        pydantic.dataclasses._validate_dataclass = orig

--- a/src/pydantic_generics/validators.py
+++ b/src/pydantic_generics/validators.py
@@ -1,5 +1,4 @@
 from itertools import zip_longest
-from inspect import isabstract
 from typing import Any, Callable, Type, TypeVar
 import dataclasses
 
@@ -15,7 +14,7 @@ class CannotCastError(pydantic.errors.PydanticTypeError):
 
 def simple_casting_validator(type_: Type[T]) -> Callable[[T], T]:
     def arbitrary_type_validator(v: Any) -> T:
-        if isinstance(v, type_) or isabstract(type_) or getattr(type_, '_is_protocol', False):
+        if isinstance(v, type_):
             return v
 
         # cast

--- a/src/pydantic_generics/validators.py
+++ b/src/pydantic_generics/validators.py
@@ -1,4 +1,5 @@
 from itertools import zip_longest
+from inspect import isabstract
 from typing import Any, Callable, Type, TypeVar
 
 import pydantic.errors
@@ -13,7 +14,7 @@ class CannotCastError(pydantic.errors.PydanticTypeError):
 
 def simple_casting_validator(type_: Type[T]) -> Callable[[T], T]:
     def arbitrary_type_validator(v: Any) -> T:
-        if isinstance(v, type_):
+        if isinstance(v, type_) or isabstract(type_) or getattr(type_, '_is_protocol', False):
             return v
 
         # cast

--- a/src/pydantic_generics/validators.py
+++ b/src/pydantic_generics/validators.py
@@ -1,6 +1,7 @@
 from itertools import zip_longest
 from inspect import isabstract
 from typing import Any, Callable, Type, TypeVar
+import dataclasses
 
 import pydantic.errors
 import pydantic.validators
@@ -108,3 +109,9 @@ def mapping_casting_validator(field) -> Callable[[T], T]:
         return result
 
     return cast_elements
+
+
+def coerce_dataclass_validator(cls):
+    def coerce_dataclass(v):
+        return cls(**dataclasses.asdict(v))
+    return coerce_dataclass

--- a/src/pydantic_generics/validators.py
+++ b/src/pydantic_generics/validators.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Type, TypeVar
 import dataclasses
 
 import pydantic.errors
-import pydantic.validators
+from pydantic.dataclasses import _validate_dataclass as _pydantic_validate_dataclass
 
 T = TypeVar("T")
 
@@ -111,7 +111,15 @@ def mapping_casting_validator(field) -> Callable[[T], T]:
     return cast_elements
 
 
+def _validate_dataclass(cls, v, field):
+    if field.allow_none and v is None:
+        return None
+    return _pydantic_validate_dataclass(cls, v)
+
+
 def coerce_dataclass_validator(cls):
     def coerce_dataclass(v):
+        if v is None:
+            return None
         return cls(**dataclasses.asdict(v))
     return coerce_dataclass

--- a/tests/test_pydantic_generics.py
+++ b/tests/test_pydantic_generics.py
@@ -296,7 +296,6 @@ OTHER_CASES = [
     (MyString, '1', '1', MyString),
     (MyValidatingString, '1', '1', MyValidatingString),
     (Callable, noop, noop, type(noop)),
-    (Color, 'red', 'red', type(Color)),
 ]
 
 
@@ -352,3 +351,13 @@ def test_python39() -> None:
     assert issubclass(Model, BaseModel)
     with pytest.raises(ValidationError):
         instance = Model(x=value)
+
+
+def test_color():
+    """test separately because == does not work on Color"""
+    class M(BaseModel):
+        c: Color
+
+    m = M(c='red')
+    assert isinstance(m.c, Color)
+    assert m.c.as_named() == 'red'

--- a/tests/test_pydantic_generics.py
+++ b/tests/test_pydantic_generics.py
@@ -332,6 +332,9 @@ OTHER_CASES = [
     # but "concrete" protocols should
     (MyConcreteProtocol, FollowsProtocol(1), MyConcreteProtocol(1), MyConcreteProtocol),
     (MyDataClass, MyDataClass(a=1), MyDataClass(a=1), MyDataClass),
+    # optional dataclass must accept None
+    (Optional[MyDataClass], MyDataClass(a=1), MyDataClass(a=1), MyDataClass),
+    (Optional[MyDataClass], None, None, type(None)),
 ]
 
 

--- a/tests/test_pydantic_generics.py
+++ b/tests/test_pydantic_generics.py
@@ -16,6 +16,9 @@ from typing import (
     Mapping,
     Tuple,
     Callable,
+    SupportsInt,
+    Protocol,
+    runtime_checkable,
 )
 
 import pytest
@@ -176,6 +179,27 @@ class MyTripleTuple(_DunderMixin, Tuple[T, U, V]):
         self.v = tuple(v)
 
 
+@runtime_checkable
+class MyProtocol(Protocol):
+    x: int
+
+
+class MyConcreteProtocol(MyProtocol):
+    def __init__(self, x):
+        self.x = x
+
+    def __eq__(self, other):
+        return self.x == self.x
+
+
+class FollowsProtocol:
+    def __init__(self, x):
+        self.x = x
+
+    def __eq__(self, other):
+        return self.x == self.x
+
+
 CASES = [
     (MyGeneric, 1),
     (MyGenericSequence, [1]),
@@ -296,6 +320,11 @@ OTHER_CASES = [
     (MyString, '1', '1', MyString),
     (MyValidatingString, '1', '1', MyValidatingString),
     (Callable, noop, noop, type(noop)),
+    # abstract classes and protocols should not be coerced
+    (SupportsInt, 1, 1, int),
+    (MyProtocol, FollowsProtocol(1), FollowsProtocol(1), FollowsProtocol),
+    # but "concrete" protocols should
+    (MyConcreteProtocol, FollowsProtocol(1), MyConcreteProtocol(1), MyConcreteProtocol)
 ]
 
 

--- a/tests/test_pydantic_generics.py
+++ b/tests/test_pydantic_generics.py
@@ -201,6 +201,11 @@ class FollowsProtocol:
         return self.x == self.x
 
 
+class DoesNotFollowProtocol:
+    def __init__(self, y):
+        self.y = y
+
+
 @dataclass
 class MyDataClass:
     a: int
@@ -357,6 +362,8 @@ FAILING_CASES = [
     # TODO: this should not fail like this
     (MyTripleParameterIterable[int, float, str], [1]),
     (MyTuple[int], (1, 1)),
+    (SupportsInt, 'asd'),
+    (MyProtocol, DoesNotFollowProtocol(1)),
 ]
 
 

--- a/tests/test_pydantic_generics.py
+++ b/tests/test_pydantic_generics.py
@@ -24,6 +24,7 @@ from typing import (
 import pytest
 from pydantic.error_wrappers import ValidationError
 from pydantic.color import Color
+from pydantic.dataclasses import dataclass
 
 from pydantic_generics import BaseModel, create_model
 
@@ -200,6 +201,11 @@ class FollowsProtocol:
         return self.x == self.x
 
 
+@dataclass
+class MyDataClass:
+    a: int
+
+
 CASES = [
     (MyGeneric, 1),
     (MyGenericSequence, [1]),
@@ -324,7 +330,8 @@ OTHER_CASES = [
     (SupportsInt, 1, 1, int),
     (MyProtocol, FollowsProtocol(1), FollowsProtocol(1), FollowsProtocol),
     # but "concrete" protocols should
-    (MyConcreteProtocol, FollowsProtocol(1), MyConcreteProtocol(1), MyConcreteProtocol)
+    (MyConcreteProtocol, FollowsProtocol(1), MyConcreteProtocol(1), MyConcreteProtocol),
+    (MyDataClass, MyDataClass(a=1), MyDataClass(a=1), MyDataClass),
 ]
 
 

--- a/tests/test_pydantic_generics.py
+++ b/tests/test_pydantic_generics.py
@@ -33,6 +33,10 @@ U = TypeVar("U")
 V = TypeVar("V")
 
 
+class Config:
+    arbitrary_types_allowed = True
+
+
 class _ClassValidatorMixin:
     @classmethod
     def __get_validators__(cls):
@@ -245,7 +249,7 @@ CASES = [
 
 @pytest.mark.parametrize("field, value", CASES)
 def test_simple_generics(field: type, value: Any) -> None:
-    Model = create_model("Model", x=(field, ...))
+    Model = create_model("Model", x=(field, ...), __config__=Config)
     assert issubclass(Model, BaseModel)
     instance = Model(x=value)
     attr = getattr(instance, "x")
@@ -299,7 +303,7 @@ PARAMETRIZED_CASES = [
 
 @pytest.mark.parametrize("field, value, expected", PARAMETRIZED_CASES)
 def test_parametrized_generics(field: type, value: Any, expected: Any) -> None:
-    Model = create_model("Model", x=(field, ...))
+    Model = create_model("Model", x=(field, ...), __config__=Config)
     assert issubclass(Model, BaseModel)
     instance = Model(x=value)
     attr = getattr(instance, "x")
@@ -345,7 +349,7 @@ OTHER_CASES = [
 
 @pytest.mark.parametrize("field, value, expected, expected_type", OTHER_CASES)
 def test_other_types(field: type, value: Any, expected: Any, expected_type: type) -> None:
-    Model = create_model("Model", x=(field, ...))
+    Model = create_model("Model", x=(field, ...), __config__=Config)
     assert issubclass(Model, BaseModel)
     instance = Model(x=value)
     attr = getattr(instance, "x")
@@ -369,7 +373,7 @@ FAILING_CASES = [
 
 @pytest.mark.parametrize("field, value", FAILING_CASES)
 def test_incompatible_types(field: type, value: Any) -> None:
-    Model = create_model("Model", x=(field, ...))
+    Model = create_model("Model", x=(field, ...), __config__=Config)
     assert issubclass(Model, BaseModel)
     with pytest.raises(ValidationError):
         Model(x=value)
@@ -380,7 +384,7 @@ def test_python39() -> None:
     field = MyTripleTuple[str, ...]
     value = (1, 2)
     expected = ('1', '2')
-    Model = create_model("Model", x=(field, ...))
+    Model = create_model("Model", x=(field, ...), __config__=Config)
     assert issubclass(Model, BaseModel)
     instance = Model(x=value)
     attr = getattr(instance, "x")
@@ -393,7 +397,7 @@ def test_python39() -> None:
     # different length of parameters and value
     field = MyTripleTuple[int, float, str]
     value = [1, 2]
-    Model = create_model("Model", x=(field, ...))
+    Model = create_model("Model", x=(field, ...), __config__=Config)
     assert issubclass(Model, BaseModel)
     with pytest.raises(ValidationError):
         instance = Model(x=value)
@@ -402,6 +406,7 @@ def test_python39() -> None:
 def test_color():
     """test separately because == does not work on Color"""
     class M(BaseModel):
+        Config = Config
         c: Color
 
     m = M(c='red')

--- a/tests/test_pydantic_generics.py
+++ b/tests/test_pydantic_generics.py
@@ -20,6 +20,7 @@ from typing import (
 
 import pytest
 from pydantic.error_wrappers import ValidationError
+from pydantic.color import Color
 
 from pydantic_generics import BaseModel, create_model
 
@@ -295,6 +296,7 @@ OTHER_CASES = [
     (MyString, '1', '1', MyString),
     (MyValidatingString, '1', '1', MyValidatingString),
     (Callable, noop, noop, type(noop)),
+    (Color, 'red', 'red', type(Color)),
 ]
 
 


### PR DESCRIPTION
One unforseen consequence of our decision to always use *both* `__get_validators__` and `find_validators` (to coerce type and do the other fancy stuff) is that types that do not have a validator in `find_validators` (such as `pydantic.color.Color`, which we use in napari) will fail if `arbitrary_types_allowed == False`.

With the current context manager monkeypathc trick, `arbitrary_types_allowed` was only set to `True` for `Generics`, otherwise to `False`.

I think at this point we should just force to use `arbitrary_types_allowed`. 